### PR TITLE
feat: README 목차에 튜토리얼 링크 연결

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,39 +20,63 @@
 
 *이 튜토리얼은 [Anthropic의 Claude for Sheets 확장 프로그램을 사용하는 Google Sheets 버전](https://docs.google.com/spreadsheets/d/19jzLgRruG9kjUQNKtCg1ZjdD6l6weA6qRXG5zLIAhC8/edit?usp=sharing)도 제공됩니다. 더 사용자 친화적이므로 해당 버전을 사용하는 것을 권장합니다.*
 
-시작할 준비가 되면 `01_Basic Prompt Structure`로 이동하여 진행하세요.
+시작할 준비가 되면 아래 목차에서 원하는 버전의 `01_Basic Prompt Structure`로 이동하여 진행하세요.
+
+## 튜토리얼 버전 선택
+
+이 저장소는 세 가지 버전의 튜토리얼을 제공합니다:
+
+- **[Anthropic 1P](./Anthropic%201P/)**: Anthropic의 직접 API를 사용하는 버전
+- **[AmazonBedrock (Anthropic)](./AmazonBedrock/anthropic/)**: Amazon Bedrock에서 Anthropic API를 사용하는 버전  
+- **[AmazonBedrock (boto3)](./AmazonBedrock/boto3/)**: Amazon Bedrock에서 boto3 라이브러리를 사용하는 버전
 
 ## 목차
 
 각 챕터는 레슨과 연습 문제 세트로 구성되어 있습니다.
 
+### 시작하기
+- **Chapter 0:** 튜토리얼 사용법
+  - [Anthropic 1P](./Anthropic%201P/00_Tutorial_How-To.ipynb) | [Bedrock (Anthropic)](./AmazonBedrock/anthropic/00_Tutorial_How-To.ipynb) | [Bedrock (boto3)](./AmazonBedrock/boto3/00_Tutorial_How-To.ipynb)
+
 ### 초급
 - **Chapter 1:** 기본 프롬프트 구조
+  - [Anthropic 1P](./Anthropic%201P/01_Basic_Prompt_Structure.ipynb) | [Bedrock (Anthropic)](./AmazonBedrock/anthropic/01_Basic_Prompt_Structure.ipynb) | [Bedrock (boto3)](./AmazonBedrock/boto3/01_Basic_Prompt_Structure.ipynb)
 
 - **Chapter 2:** 명확하고 직접적으로 표현하기
+  - [Anthropic 1P](./Anthropic%201P/02_Being_Clear_and_Direct.ipynb) | [Bedrock (Anthropic)](./AmazonBedrock/anthropic/02_Being_Clear_and_Direct.ipynb) | [Bedrock (boto3)](./AmazonBedrock/boto3/02_Being_Clear_and_Direct.ipynb)
 
 - **Chapter 3:** 역할 할당하기
+  - [Anthropic 1P](./Anthropic%201P/03_Assigning_Roles_Role_Prompting.ipynb) | [Bedrock (Anthropic)](./AmazonBedrock/anthropic/03_Assigning_Roles_Role_Prompting.ipynb) | [Bedrock (boto3)](./AmazonBedrock/boto3/03_Assigning_Roles_Role_Prompting.ipynb)
 
 ### 중급 
 - **Chapter 4:** 데이터와 지시사항 분리하기
+  - [Anthropic 1P](./Anthropic%201P/04_Separating_Data_and_Instructions.ipynb) | [Bedrock (Anthropic)](./AmazonBedrock/anthropic/04_Separating_Data_and_Instructions.ipynb) | [Bedrock (boto3)](./AmazonBedrock/boto3/04_Separating_Data_and_Instructions.ipynb)
 
 - **Chapter 5:** 출력 형식 지정 및 Claude를 대신해서 말하기
+  - [Anthropic 1P](./Anthropic%201P/05_Formatting_Output_and_Speaking_for_Claude.ipynb) | [Bedrock (Anthropic)](./AmazonBedrock/anthropic/05_Formatting_Output_and_Speaking_for_Claude.ipynb) | [Bedrock (boto3)](./AmazonBedrock/boto3/05_Formatting_Output_and_Speaking_for_Claude.ipynb)
 
 - **Chapter 6:** Precognition (단계별로 생각하기)
+  - [Anthropic 1P](./Anthropic%201P/06_Precognition_Thinking_Step_by_Step.ipynb) | [Bedrock (Anthropic)](./AmazonBedrock/anthropic/06_Precognition_Thinking_Step_by_Step.ipynb) | [Bedrock (boto3)](./AmazonBedrock/boto3/06_Precognition_Thinking_Step_by_Step.ipynb)
 
 - **Chapter 7:** 예시 사용하기
+  - [Anthropic 1P](./Anthropic%201P/07_Using_Examples_Few-Shot_Prompting.ipynb) | [Bedrock (Anthropic)](./AmazonBedrock/anthropic/07_Using_Examples%20_Few-Shot_Prompting.ipynb) | [Bedrock (boto3)](./AmazonBedrock/boto3/07_Using_Examples_Few-Shot_Prompting.ipynb)
 
 ### 고급
 - **Chapter 8:** Hallucination 방지하기
+  - [Anthropic 1P](./Anthropic%201P/08_Avoiding_Hallucinations.ipynb) | [Bedrock (Anthropic)](./AmazonBedrock/anthropic/08_Avoiding_Hallucinations.ipynb) | [Bedrock (boto3)](./AmazonBedrock/boto3/08_Avoiding_Hallucinations.ipynb)
 
 - **Chapter 9:** 복잡한 프롬프트 구축하기 (산업별 사용 사례)
-  - 처음부터 복잡한 프롬프트 만들기 - 챗봇
-  - 법률 서비스를 위한 복잡한 프롬프트
-  - **연습문제:** 금융 서비스를 위한 복잡한 프롬프트
-  - **연습문제:** 코딩을 위한 복잡한 프롬프트
-  - 축하합니다 & 다음 단계
+  - [Anthropic 1P](./Anthropic%201P/09_Complex_Prompts_from_Scratch.ipynb) | [Bedrock (Anthropic)](./AmazonBedrock/anthropic/09_Complex_Prompts_from_Scratch.ipynb) | [Bedrock (boto3)](./AmazonBedrock/boto3/09_Complex_Prompts_from_Scratch.ipynb)
 
-- **부록:** 표준 프롬프팅을 넘어서
-  - 프롬프트 연결하기
-  - 도구 사용
-  - Search & Retrieval
+### 부록: 표준 프롬프팅을 넘어서
+- **부록 1:** 프롬프트 연결하기
+  - [Anthropic 1P](./Anthropic%201P/10.1_Appendix_Chaining%20Prompts.ipynb) | [Bedrock (Anthropic)](./AmazonBedrock/anthropic/10_1_Appendix_Chaining_Prompts.ipynb) | [Bedrock (boto3)](./AmazonBedrock/boto3/10_1_Appendix_Chaining_Prompts.ipynb)
+
+- **부록 2:** 도구 사용
+  - [Anthropic 1P](./Anthropic%201P/10.2_Appendix_Tool%20Use.ipynb) | [Bedrock (Anthropic)](./AmazonBedrock/anthropic/10_2_Appendix_Tool_Use.ipynb) | [Bedrock (boto3)](./AmazonBedrock/boto3/10_2_Appendix_Tool_Use.ipynb)
+
+- **부록 3:** Search & Retrieval
+  - [Anthropic 1P](./Anthropic%201P/10.3_Appendix_Search%20&%20Retrieval.ipynb) | [Bedrock (Anthropic)](./AmazonBedrock/anthropic/10_4_Appendix_Search_and_Retrieval.ipynb) | [Bedrock (boto3)](./AmazonBedrock/boto3/10_4_Appendix_Search_and_Retrieval.ipynb)
+
+- **부록 4:** 경험적 성능 평가 (Bedrock 전용)
+  - [Bedrock (Anthropic)](./AmazonBedrock/anthropic/10_3_Appendix_Empirical_Performance_Evaluations.ipynb) | [Bedrock (boto3)](./AmazonBedrock/boto3/10_3_Appendix_Empirical_Performance_Eval.ipynb)

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@
   - [Anthropic 1P](./Anthropic%201P/06_Precognition_Thinking_Step_by_Step.ipynb) | [Bedrock (Anthropic)](./AmazonBedrock/anthropic/06_Precognition_Thinking_Step_by_Step.ipynb) | [Bedrock (boto3)](./AmazonBedrock/boto3/06_Precognition_Thinking_Step_by_Step.ipynb)
 
 - **Chapter 7:** 예시 사용하기
-  - [Anthropic 1P](./Anthropic%201P/07_Using_Examples_Few-Shot_Prompting.ipynb) | [Bedrock (Anthropic)](./AmazonBedrock/anthropic/07_Using_Examples%20_Few-Shot_Prompting.ipynb) | [Bedrock (boto3)](./AmazonBedrock/boto3/07_Using_Examples_Few-Shot_Prompting.ipynb)
+  - [Anthropic 1P](./Anthropic%201P/07_Using_Examples_Few-Shot_Prompting.ipynb) | [Bedrock (Anthropic)](./AmazonBedrock/anthropic/07_Using_Examples _Few-Shot_Prompting.ipynb) | [Bedrock (boto3)](./AmazonBedrock/boto3/07_Using_Examples_Few-Shot_Prompting.ipynb)
 
 ### 고급
 - **Chapter 8:** Hallucination 방지하기


### PR DESCRIPTION
README 목차에 Anthropic 튜토리얼 파일들에 대한 링크를 추가했습니다.

## 변경 사항
- 세 가지 튜토리얼 버전에 대한 링크 추가
- 모든 챕터와 부록에 대한 직접 링크 제공
- 튜토리얼 버전 선택 섹션 추가

Closes #4

Generated with [Claude Code](https://claude.ai/code)